### PR TITLE
Feature/edge tidy

### DIFF
--- a/__tests__/filtering.test.js
+++ b/__tests__/filtering.test.js
@@ -5,7 +5,7 @@ const fasterFilter = require('../faster-filter').fasterFilter;
 // construction from https://github.com/codaco/Network-Canvas/wiki/Network-Query-Builder
 const makeFilter = logic =>
   query[logic.join.toLowerCase()](logic.rules.map(rule => query[`${rule.type}Rule`](rule.options)));
-const filter = (network, logic) => makeFilter(logic)(network);
+const filter = (network, logic) => query.repair(makeFilter(logic))(network);
 
 const makeOrLogic = (...rules) => ({ join: 'OR', rules });
 const makeAndLogic = (...rules) => ({ join: 'AND', rules });
@@ -23,14 +23,18 @@ describe('filtering', () => {
 
   describe('a simple network', () => {
     const network = Object.freeze({
-      nodes: [person('Me'), person('Carl')],
-      edges: [{ from: 1, to: 2, type: 'friends' }],
+      nodes: [person('Me'), person('Carl'), person('Theodore')],
+      edges: [
+        { from: 1, to: 2, type: 'friends' },
+        { from: 1, to: 2, type: 'running_club' },
+        { from: 1, to: 3, type: 'friends' },
+      ],
     });
 
-    it('returns one edge', () => {
-      const logic = makeOrLogic(edgeRule({ operator: 'EXISTS', type: 'friends' }));
-      expect(fasterFilter(network, logic).edges).toHaveLength(1);
-      expect(filter(network, logic).edges).toHaveLength(1);
+    it('edge rule is node centric, missing edges are reinstated', () => {
+      const logic = makeOrLogic(edgeRule({ operator: 'EXISTS', type: 'running_club' }));
+      expect(fasterFilter(network, logic).edges).toHaveLength(2);
+      expect(filter(network, logic).edges).toHaveLength(2);
     });
 
     it('returns one node with ego rule', () => {

--- a/query.js
+++ b/query.js
@@ -15,9 +15,13 @@ const nodePrimaryKeyProperty = require('./nodePrimaryKeyProperty');
 
 /*
 
-Premise, using additive pipes to filter network.
+AND applies filters sucessively
 
-network -> filterA -> filterB -> output;
+filterB(filterA(network)) = output;
+
+OR applies them individually and joins
+
+filterA(network) + filterB(network) = output;
 
 // PSEUDOCODE
 


### PR DESCRIPTION
I'm not sure where this repair function ought to live:

The premise is that, the query is node centric, and we may be missing much of the network if going through an and() type query - the repair function adds a fresh copy of the edges relevant to any remaining nodes.